### PR TITLE
Add conditional inclusion of varatt.h for PostgreSQL 16+

### DIFF
--- a/argm.c
+++ b/argm.c
@@ -1,5 +1,10 @@
 #include "postgres.h"
 #include "fmgr.h"
+
+#if PG_VERSION_NUM >= 160000
+    #include "varatt.h"
+#endif
+
 #include "lib/stringinfo.h"
 #include "libpq/pqformat.h"
 #include "utils/datum.h"


### PR DESCRIPTION
### Summary
This PR adds support for PostgreSQL 16 by conditionally including varatt.h, which now contains macros previously found in postgres.h.

### Changes
- Uses PG_VERSION_NUM to conditionally include varatt.h for PostgreSQL versions 16 and above.
